### PR TITLE
Add description length limit

### DIFF
--- a/packages/frontend/src/creation-form/components/generic-data/index.tsx
+++ b/packages/frontend/src/creation-form/components/generic-data/index.tsx
@@ -12,6 +12,7 @@ import {
 import { BigNumber, utils } from "ethers";
 import { isInThePast } from "../../../utils/dates";
 import { NoSpecialCharactersTextInput } from "../no-special-characters-text-input";
+import { MAX_KPI_TOKEN_DESCRIPTION_CHARS } from "../../constants";
 
 const stripHtml = (value: string) => value.replace(/(<([^>]+)>)/gi, "");
 
@@ -80,6 +81,8 @@ export const GenericData = ({
                 !erc20Symbol ||
                 !title.trim() ||
                 !stripHtml(description).trim() ||
+                stripHtml(description).trim().length >
+                    MAX_KPI_TOKEN_DESCRIPTION_CHARS ||
                 tags.length === 0 ||
                 !expiration ||
                 isInThePast(expiration) ||
@@ -111,7 +114,11 @@ export const GenericData = ({
             const trimmedValue = stripHtml(value).trim();
             setDescription(value);
             setDescriptionErrorText(
-                !trimmedValue ? t("error.description.empty") : ""
+                !trimmedValue
+                    ? t("error.description.empty")
+                    : trimmedValue.length > MAX_KPI_TOKEN_DESCRIPTION_CHARS
+                    ? t("error.description.tooLong")
+                    : ""
             );
         },
         [t]

--- a/packages/frontend/src/creation-form/constants/index.ts
+++ b/packages/frontend/src/creation-form/constants/index.ts
@@ -11,6 +11,8 @@ export const TOKEN_LIST_URLS: string[] = [CARROT_LIST, COINGECKO_LIST];
 
 export const PROTOCOL_FEE_BPS = 30;
 
+export const MAX_KPI_TOKEN_DESCRIPTION_CHARS = 256;
+
 export const CREATION_PROXY_ADDRESS: Record<ChainId, Address> = {
     [ChainId.GNOSIS]: "0xc9CC9a4d4F2c57F0d47c169A3d96D47FfFe5E0b6",
     [ChainId.SEPOLIA]: "0xd5192f7DB2c20764aa66336F61f711e3Fe9CC43C",

--- a/packages/frontend/src/creation-form/i18n/en.json
+++ b/packages/frontend/src/creation-form/i18n/en.json
@@ -29,6 +29,7 @@
     "general.placeholder.expiration": "Pick a future date",
     "error.title.empty": "A campaign title is required",
     "error.description.empty": "A campaign description is required",
+    "error.description.tooLong": "Your description must be less that 256 characters",
     "error.tags.empty": "A campaign tag is required",
     "error.tags.duplicated": "Duplicated campaign tag",
     "error.expiration.past": "The expiration must be in the future",


### PR DESCRIPTION
Add a maximum chars limit to the KPI token description input.
Fixes https://github.com/carrot-kpi/erc20-kpi-token-template/issues/69.