### PR TITLE
feat(frontend): implement automatic outcomes configuration filling based on oracle configuration

### DIFF
--- a/packages/frontend/src/creation-form/components/oracles-configuration/index.tsx
+++ b/packages/frontend/src/creation-form/components/oracles-configuration/index.tsx
@@ -85,7 +85,6 @@ export const OraclesConfiguration = ({
             onStateChange({
                 ...state,
                 [templateId]: {
-                    ...state?.[templateId],
                     state: oracleState,
                     initializationBundleGetter,
                 },
@@ -103,10 +102,11 @@ export const OraclesConfiguration = ({
                     Object.values(state).map(async (item) => {
                         const initializationBundle =
                             await item.initializationBundleGetter();
-                        return {
-                            ...item,
+                        const oracleData: OracleData = {
+                            state: item.state,
                             initializationBundle,
                         };
+                        return oracleData;
                     })
                 );
                 onNext(oracles);

--- a/packages/frontend/src/creation-form/components/outcomes-configuration/index.tsx
+++ b/packages/frontend/src/creation-form/components/outcomes-configuration/index.tsx
@@ -123,6 +123,9 @@ export const OutcomesConfiguration = ({
                 <SingleConfiguration
                     t={t}
                     templateId={templates[0].id}
+                    automaticallyFilled={
+                        state[templates[0].id]?.automaticallyFilled
+                    }
                     binary={state[templates[0].id]?.binary}
                     onBinaryChange={handleBinaryChange}
                     lowerBound={state[templates[0].id]?.lowerBound}

--- a/packages/frontend/src/creation-form/components/outcomes-configuration/oracles-accordion/index.tsx
+++ b/packages/frontend/src/creation-form/components/outcomes-configuration/oracles-accordion/index.tsx
@@ -54,6 +54,9 @@ export const OraclesAccordion = ({
                             <SingleConfiguration
                                 t={t}
                                 templateId={template.id}
+                                automaticallyFilled={
+                                    data[id]?.automaticallyFilled
+                                }
                                 binary={data[id]?.binary}
                                 onBinaryChange={onBinaryChange}
                                 lowerBound={data[id]?.lowerBound}

--- a/packages/frontend/src/creation-form/components/outcomes-configuration/single-configuration/index.tsx
+++ b/packages/frontend/src/creation-form/components/outcomes-configuration/single-configuration/index.tsx
@@ -15,6 +15,7 @@ const boundsWrapperStyles = cva(["flex gap-4 opacity-100 transition-opacity"], {
 export interface SingleConfigurationProps {
     t: NamespacedTranslateFunction;
     templateId: number;
+    automaticallyFilled?: boolean;
     binary?: boolean;
     onBinaryChange?: (id: number, value: boolean) => void;
     lowerBound?: NumberFormatValue;
@@ -26,6 +27,7 @@ export interface SingleConfigurationProps {
 export const SingleConfiguration = ({
     t,
     templateId,
+    automaticallyFilled,
     binary,
     onBinaryChange,
     lowerBound,
@@ -56,6 +58,13 @@ export const SingleConfiguration = ({
 
     return (
         <div className="flex flex-col gap-4">
+            {automaticallyFilled && (
+                <div className="rounded-xl flex p-4 border border-orange bg-orange bg-opacity-20">
+                    <Typography className={{ root: "text-orange" }}>
+                        {t("warning.autofilled")}
+                    </Typography>
+                </div>
+            )}
             <div className="flex justify-between items-center">
                 <Typography>{t("label.binary")}</Typography>
                 <Switch checked={binary} onChange={handleBinaryChange} />

--- a/packages/frontend/src/creation-form/constants/index.ts
+++ b/packages/frontend/src/creation-form/constants/index.ts
@@ -1,5 +1,6 @@
 import { ChainId } from "@carrot-kpi/sdk";
 import { Address } from "wagmi";
+import { OutcomeConfigurationState } from "../types";
 
 export const NO_SPECIAL_CHARACTERS_REGEX =
     /^[A-Z0-9@~`!@#$%^&*()_=+\\';:"\/?>.<,-\s]*$/i;
@@ -21,4 +22,17 @@ export const MAX_KPI_TOKEN_TAGS_COUNT = 10;
 export const CREATION_PROXY_ADDRESS: Record<ChainId, Address> = {
     [ChainId.GNOSIS]: "0xc9CC9a4d4F2c57F0d47c169A3d96D47FfFe5E0b6",
     [ChainId.SEPOLIA]: "0xd5192f7DB2c20764aa66336F61f711e3Fe9CC43C",
+};
+
+export const DEFAULT_OUTCOME_CONFIGURATION: OutcomeConfigurationState = {
+    automaticallyFilled: false,
+    binary: false,
+    lowerBound: {
+        value: "",
+        formattedValue: "",
+    },
+    higherBound: {
+        value: "",
+        formattedValue: "",
+    },
 };

--- a/packages/frontend/src/creation-form/i18n/en.json
+++ b/packages/frontend/src/creation-form/i18n/en.json
@@ -84,5 +84,6 @@
     "step": "Step",
     "add": "Add",
     "success.text": "Your Carrot Campaign has successfully been created!",
-    "success.button.label": "Go to campaign"
+    "success.button.label": "Go to campaign",
+    "warning.autofilled": "This outcome configuration has been automatically determined based on its respective oracle configuration. Please manually double check for any discrepancies, it's important."
 }

--- a/packages/frontend/src/creation-form/index.tsx
+++ b/packages/frontend/src/creation-form/index.tsx
@@ -29,6 +29,7 @@ import { Deploy } from "./components/deploy";
 import { CREATION_PROXY_ADDRESS } from "./constants";
 import { Success } from "./components/success";
 import { ConnectWallet } from "./components/connect-wallet";
+import { outcomeConfigurationFromOracleData } from "./utils/outcomes-configuration";
 
 // TODO: add a check that displays an error message if the creation
 // proxy address is 0 for more than x time
@@ -122,6 +123,31 @@ export const Component = ({
         if (oracleTemplates.length === 1 && oracleTemplatesData.length === 0)
             setOracleTemplatesData([oracleTemplates[0]]);
     }, [oracleTemplates, oracleTemplatesData.length]);
+
+    // when oracles have been configured, we TRY to configure outcomes
+    // automatically based on the specific picked oracle templates.
+    // if we can't do that, we just fallback to a default value and the
+    // user has to specify the configuration himself
+    useEffect(() => {
+        const outcomesConfigurationStepState = Object.entries(
+            oraclesConfigurationStepState
+        ).reduce(
+            (
+                accumulator: OutcomesConfigurationStepState,
+                [templateId, data]
+            ) => {
+                const parsedTemplateID = parseInt(templateId);
+                if (isNaN(parsedTemplateID))
+                    // this should never happen, it's here just for extra safety
+                    return accumulator;
+                accumulator[parsedTemplateID] =
+                    outcomeConfigurationFromOracleData(parsedTemplateID, data);
+                return accumulator;
+            },
+            {}
+        );
+        setOutcomesConfigurationStepState(outcomesConfigurationStepState);
+    }, [oraclesConfigurationStepState]);
 
     const handleStepClick = useCallback((clickedStep: number) => {
         setStep(clickedStep);

--- a/packages/frontend/src/creation-form/types.ts
+++ b/packages/frontend/src/creation-form/types.ts
@@ -75,10 +75,13 @@ export interface OutcomeData {
     higherBound: BigNumber;
 }
 
+export interface OutcomeConfigurationState {
+    automaticallyFilled?: boolean;
+    binary: boolean;
+    lowerBound: NumberFormatValue;
+    higherBound: NumberFormatValue;
+}
+
 export type OutcomesConfigurationStepState = {
-    [id: number]: {
-        binary: boolean;
-        lowerBound: NumberFormatValue;
-        higherBound: NumberFormatValue;
-    };
+    [templateId: number]: OutcomeConfigurationState;
 };

--- a/packages/frontend/src/creation-form/utils/outcomes-configuration.ts
+++ b/packages/frontend/src/creation-form/utils/outcomes-configuration.ts
@@ -1,0 +1,33 @@
+import { DEFAULT_OUTCOME_CONFIGURATION } from "../constants";
+import { OracleData, OutcomeConfigurationState } from "../types";
+
+export const outcomeConfigurationFromOracleData = (
+    templateId: number,
+    oracleData: OracleData
+): OutcomeConfigurationState => {
+    switch (templateId) {
+        // reality.eth oracle template
+        case 1: {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const usedRealityTemplate = (oracleData.state as any)
+                .realityTemplateId as string;
+            return usedRealityTemplate === "0"
+                ? {
+                      automaticallyFilled: true,
+                      binary: true,
+                      lowerBound: {
+                          value: "",
+                          formattedValue: "",
+                      },
+                      higherBound: {
+                          value: "",
+                          formattedValue: "",
+                      },
+                  }
+                : DEFAULT_OUTCOME_CONFIGURATION;
+        }
+        default: {
+            return DEFAULT_OUTCOME_CONFIGURATION;
+        }
+    }
+};

--- a/packages/frontend/src/creation-form/utils/outcomes-configuration.ts
+++ b/packages/frontend/src/creation-form/utils/outcomes-configuration.ts
@@ -16,11 +16,11 @@ export const outcomeConfigurationFromOracleData = (
                       automaticallyFilled: true,
                       binary: true,
                       lowerBound: {
-                          value: "",
+                          value: "0",
                           formattedValue: "",
                       },
                       higherBound: {
-                          value: "",
+                          value: "1",
                           formattedValue: "",
                       },
                   }


### PR DESCRIPTION
As the title says, this implements a way for the ERC20 KPI token creation form to auto-fill some data related to outcomes in order to make it easier for users to use the platform.

The implemented logic is flexible and extensible, but for now only logic specific to the Reality.eth oracle is implemented. In particular, if the picked Reality.eth template is the binary one, the outcome configuration for the oracle is also prefilled to be binary, ensuring a match there. 

When an outcome cofiguration form has been autofilled, this is shown to the user:

![image](https://user-images.githubusercontent.com/12766550/228792971-322a6636-176a-442f-a540-b7ed97e4fe55.png)
