### PR TITLE
Fix infinite loop

### DIFF
--- a/packages/frontend/src/creation-form/components/deploy/index.tsx
+++ b/packages/frontend/src/creation-form/components/deploy/index.tsx
@@ -106,6 +106,7 @@ export const Deploy = ({
         const newToApprove = [];
         for (let i = 0; i < collateralsData.length; i++) {
             const collateralData = collateralsData[i];
+            if (!allowances[i]) return;
             if (
                 (allowances[i] as unknown as BigNumber).gte(
                     collateralData.amount.raw

--- a/packages/frontend/src/creation-form/components/oracles-configuration/index.tsx
+++ b/packages/frontend/src/creation-form/components/oracles-configuration/index.tsx
@@ -1,4 +1,11 @@
-import { ReactElement, useCallback, useEffect, useState } from "react";
+import {
+    Dispatch,
+    ReactElement,
+    SetStateAction,
+    useCallback,
+    useEffect,
+    useState,
+} from "react";
 import {
     KPITokenCreationFormProps,
     NamespacedTranslateFunction,
@@ -37,7 +44,7 @@ interface OraclesConfigurationProps {
     templates: Template[];
     specificationData?: SpecificationData | null;
     state: OraclesConfigurationStepState;
-    onStateChange: (state: OraclesConfigurationStepState) => void;
+    onStateChange: Dispatch<SetStateAction<OraclesConfigurationStepState>>;
     onNext: (oraclesData: OracleData[]) => void;
     navigate: KPITokenCreationFormProps["navigate"];
     onTx: KPITokenCreationFormProps["onTx"];
@@ -82,15 +89,15 @@ export const OraclesConfiguration = ({
             oracleState: Partial<unknown>,
             initializationBundleGetter?: OracleInitializationBundleGetter
         ) => {
-            onStateChange({
-                ...state,
+            onStateChange((prevState) => ({
+                ...prevState,
                 [templateId]: {
                     state: oracleState,
                     initializationBundleGetter,
                 },
-            });
+            }));
         },
-        [onStateChange, state]
+        [onStateChange]
     );
 
     const handleNext = useCallback(() => {


### PR DESCRIPTION
The `OraclesConfiguration` component was generating an infinite loop caused by the `state` prop being used as a dependency in the `useCallback` array.