### PR TITLE
Issue when skipping steps

### DIFF
--- a/packages/frontend/src/creation-form/index.tsx
+++ b/packages/frontend/src/creation-form/index.tsx
@@ -152,6 +152,7 @@ export const Component = ({
 
     const handleStepClick = useCallback((clickedStep: number) => {
         setStep(clickedStep);
+        setMostUpdatedStep(clickedStep);
     }, []);
 
     const handleGenericDataNext = useCallback(
@@ -159,37 +160,34 @@ export const Component = ({
             setSpecificationData(specificationData);
             setTokenData(tokenData);
             setStep(1);
-            if (mostUpdatedStep < 1) setMostUpdatedStep(1);
+            setMostUpdatedStep(1);
         },
-        [mostUpdatedStep]
+        []
     );
 
     const handleCollateralsNext = useCallback(
         (collaterals: CollateralData[]) => {
             setCollateralsData(collaterals);
             setStep(2);
-            if (mostUpdatedStep < 2) setMostUpdatedStep(2);
+            setMostUpdatedStep(2);
         },
-        [mostUpdatedStep]
+        []
     );
 
-    const handleOraclesPickerNext = useCallback(
-        (templates: Template[]) => {
-            setOracleTemplatesData(templates);
-            setStep(3);
-            if (mostUpdatedStep < 3) setMostUpdatedStep(3);
-        },
-        [mostUpdatedStep]
-    );
+    const handleOraclesPickerNext = useCallback((templates: Template[]) => {
+        setOracleTemplatesData(templates);
+        setStep(3);
+        setMostUpdatedStep(3);
+    }, []);
 
     const handleOraclesConfigurationNext = useCallback(
         (oracleData: OracleData[]) => {
             setOraclesData(oracleData);
             const nextStep = enableOraclePickStep ? 4 : 3;
             setStep(nextStep);
-            if (mostUpdatedStep < nextStep) setMostUpdatedStep(nextStep);
+            setMostUpdatedStep(nextStep);
         },
-        [enableOraclePickStep, mostUpdatedStep]
+        [enableOraclePickStep]
     );
 
     const handleOutcomesConfigurationNext = useCallback(
@@ -197,9 +195,9 @@ export const Component = ({
             setOutcomesData(outcomesData);
             const nextStep = enableOraclePickStep ? 5 : 4;
             setStep(nextStep);
-            if (mostUpdatedStep < nextStep) setMostUpdatedStep(nextStep);
+            setMostUpdatedStep(nextStep);
         },
-        [enableOraclePickStep, mostUpdatedStep]
+        [enableOraclePickStep]
     );
 
     const handleDeployNext = useCallback(
@@ -207,9 +205,9 @@ export const Component = ({
             setCreatedKPITokenAddress(address);
             const nextStep = enableOraclePickStep ? 6 : 5;
             setStep(nextStep);
-            if (mostUpdatedStep < nextStep) setMostUpdatedStep(nextStep);
+            setMostUpdatedStep(nextStep);
         },
-        [enableOraclePickStep, mostUpdatedStep]
+        [enableOraclePickStep]
     );
 
     if (loading) {


### PR DESCRIPTION
Having the possibility to skip already completed steps caused an issue with the Oracle configuration step, because if the user completes it, then when on the last step decides to go back and change something (like the timeout for the question), and then clicks on the stepper to jump directly on the last step (avoiding to click the `next` button) the Oracle data are not updated.

Another case could be if the user changes the type of the question, from `binary` to `number` he **must** also go through the `outcome configuration` step, in order to provide the bonds.

To solve this we remove the possibility to navigate forward on the already completed steps, thus forcing the user to click `next` on every step (we keep the backward navigation).